### PR TITLE
Add Trash view with soft delete

### DIFF
--- a/SkyGraph/Components/Location Comp/TrashedLocation.swift
+++ b/SkyGraph/Components/Location Comp/TrashedLocation.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Wrapper for a deleted location with a timestamp
+struct TrashedLocation: Identifiable, Codable, Equatable {
+    var id: UUID = UUID()
+    var location: LocationDisplay
+    /// Timestamp when the location was moved to trash
+    var deletedAt: Date
+    
+    /// Returns true if item has been in trash for more than 30 days
+    var isExpired: Bool {
+        Date().timeIntervalSince(deletedAt) > 60 * 60 * 24 * 30
+    }
+}

--- a/SkyGraph/Components/NavBar.swift
+++ b/SkyGraph/Components/NavBar.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum NavBarTab: Int, CaseIterable {
-    case home, forecast, maps, ai, settings
+    case home, forecast, maps, ai, trash, settings
 
     var iconName: String {
         switch self {
@@ -9,6 +9,7 @@ enum NavBarTab: Int, CaseIterable {
         case .forecast: return "chart.line.uptrend.xyaxis"
         case .maps: return "map"
         case .ai: return "bubble.left.and.bubble.right"
+        case .trash: return "trash"
         case .settings: return "gearshape"
         }
     }
@@ -18,6 +19,7 @@ enum NavBarTab: Int, CaseIterable {
         case .forecast: return "Forecast"
         case .maps: return "Maps"
         case .ai: return "AI"
+        case .trash: return "Trash"
         case .settings: return "Settings"
         }
     }

--- a/SkyGraph/ContentView.swift
+++ b/SkyGraph/ContentView.swift
@@ -25,6 +25,8 @@ struct ContentView: View {
                         Text("AI Page")
                             .font(.largeTitle)
                             .foregroundColor(.gray)
+                    case .trash:
+                        TrashView()
                     case .settings:
                         NavigationView {
                             List {

--- a/SkyGraph/Views/LocationsView.swift
+++ b/SkyGraph/Views/LocationsView.swift
@@ -34,6 +34,7 @@ private let defaultLocations: [LocationDisplay] = [
 
 struct LocationsView: View {
     @AppStorage("savedLocations") private var savedLocationsData: Data = Data()
+    @AppStorage("trashedLocations") private var trashedLocationsData: Data = Data()
     @State private var locations: [LocationDisplay] = []
     @State private var showingAddLocation = false
     @State private var selectedLocationID: UUID? = nil
@@ -209,6 +210,7 @@ struct LocationsView: View {
         }
         .alert("Delete this location?", isPresented: $showDeleteAlert, presenting: locationToDelete) { loc in
             Button("Delete", role: .destructive) {
+                moveToTrash(loc)
                 locations.removeAll(where: { $0.id == loc.id })
             }
             Button("Cancel", role: .cancel) { }
@@ -241,6 +243,18 @@ struct LocationsView: View {
         if let encoded = try? JSONEncoder().encode(locations) {
             savedLocationsData = encoded
         }
+    }
+
+    private func moveToTrash(_ loc: LocationDisplay) {
+        var current = loadTrashed()
+        current.append(TrashedLocation(location: loc, deletedAt: Date()))
+        if let encoded = try? JSONEncoder().encode(current) {
+            trashedLocationsData = encoded
+        }
+    }
+
+    private func loadTrashed() -> [TrashedLocation] {
+        (try? JSONDecoder().decode([TrashedLocation].self, from: trashedLocationsData)) ?? []
     }
 
     func importantWeatherText(for model: LocationModel) -> String {

--- a/SkyGraph/Views/TrashView.swift
+++ b/SkyGraph/Views/TrashView.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+
+/// View for displaying and managing trashed locations
+struct TrashView: View {
+    @AppStorage("trashedLocations") private var trashedData: Data = Data()
+    @State private var trashedLocations: [TrashedLocation] = []
+    @State private var editMode = false
+    @State private var selection = Set<UUID>()
+    @State private var showUndo = false
+    @State private var undoAction: (() -> Void)?
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                ScrollView {
+                    LazyVStack(spacing: 20) {
+                        ForEach(trashedLocations) { trash in
+                            LocationWeatherCard(
+                                location: trash.location.model,
+                                isActive: false,
+                                alertTitle: trash.location.alertTitle,
+                                cardStyle: .glass,
+                                onExpand: {},
+                                importantText: importantWeatherText(for: trash.location.model)
+                            )
+                            .overlay(actionButtons(for: trash))
+                            .transition(.asymmetric(insertion: .scale.combined(with: .opacity),
+                                                    removal: .move(edge: .trailing).combined(with: .opacity)))
+                            .animation(.spring(), value: trashedLocations)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 28)
+                                    .stroke(Color.red.opacity(selection.contains(trash.id) ? 0.8 : 0), lineWidth: 3)
+                            )
+                            .onTapGesture {
+                                if editMode {
+                                    toggleSelection(trash)
+                                }
+                            }
+                            .accessibilityElement(children: .combine)
+                            .accessibilityLabel(Text("\(trash.location.model.city) trashed"))
+                        }
+                    }
+                    .padding()
+                }
+            }
+            if showUndo {
+                UndoSnackbar { undoAction?(); hideUndo() }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .animation(.spring(), value: showUndo)
+            }
+        }
+        .background(Color("Background").ignoresSafeArea())
+        .navigationTitle("Trash")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(editMode ? "Done" : "Select") {
+                    withAnimation { editMode.toggle(); selection.removeAll() }
+                }
+            }
+            if editMode {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: batchRestore) { Text("Restore") }
+                        .disabled(selection.isEmpty)
+                }
+                ToolbarItem(placement: .bottomBar) {
+                    Button(role: .destructive, action: batchDelete) { Text("Delete") }
+                        .disabled(selection.isEmpty)
+                }
+            }
+        }
+        .onAppear {
+            load()
+            removeExpiredAnimated()
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Trashed Locations")
+                .font(.system(size: 36, weight: .bold))
+                .foregroundColor(Color("Text Primary"))
+            Spacer()
+        }
+        .padding(.horizontal)
+    }
+
+    private func actionButtons(for trash: TrashedLocation) -> some View {
+        HStack {
+            Spacer()
+            VStack {
+                Button {
+                    restore(trash)
+                } label: {
+                    Image(systemName: "arrow.uturn.left")
+                        .padding(8)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Circle())
+                }
+                .buttonStyle(PlainButtonStyle())
+                .accessibilityLabel(Text("Restore \(trash.location.model.city)"))
+
+                Button(role: .destructive) {
+                    deleteForever(trash)
+                } label: {
+                    Image(systemName: "trash")
+                        .padding(8)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Circle())
+                }
+                .buttonStyle(PlainButtonStyle())
+                .accessibilityLabel(Text("Delete \(trash.location.model.city) forever"))
+            }
+        }
+        .padding(.trailing, 12)
+    }
+
+    private func toggleSelection(_ trash: TrashedLocation) {
+        if selection.contains(trash.id) {
+            selection.remove(trash.id)
+        } else {
+            selection.insert(trash.id)
+        }
+    }
+
+    private func batchRestore() {
+        let selected = trashedLocations.filter { selection.contains($0.id) }
+        selection.removeAll()
+        for trash in selected { restore(trash, showSnack: false) }
+        showUndo(action: { moveAllToTrash(selected) })
+    }
+
+    private func batchDelete() {
+        let selected = trashedLocations.filter { selection.contains($0.id) }
+        selection.removeAll()
+        for trash in selected { deleteForever(trash, showSnack: false) }
+        showUndo(action: { trashedLocations.append(contentsOf: selected); save() })
+    }
+
+    private func restore(_ trash: TrashedLocation, showSnack: Bool = true) {
+        guard let index = trashedLocations.firstIndex(where: { $0.id == trash.id }) else { return }
+        withAnimation {
+            trashedLocations.remove(at: index)
+        }
+        save()
+        if showSnack {
+            showUndo(action: { trashedLocations.insert(trash, at: index); save() })
+        }
+    }
+
+    private func deleteForever(_ trash: TrashedLocation, showSnack: Bool = true) {
+        guard let index = trashedLocations.firstIndex(where: { $0.id == trash.id }) else { return }
+        withAnimation(.easeIn(duration: 0.35)) {
+            trashedLocations.remove(at: index)
+        }
+        save()
+        if showSnack {
+            showUndo(action: { trashedLocations.insert(trash, at: index); save() })
+        }
+    }
+
+    private func moveAllToTrash(_ items: [TrashedLocation]) {
+        trashedLocations.append(contentsOf: items)
+        save()
+    }
+
+    private func showUndo(action: @escaping () -> Void) {
+        undoAction = action
+        withAnimation { showUndo = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            hideUndo()
+        }
+    }
+
+    private func hideUndo() {
+        withAnimation { showUndo = false }
+        undoAction = nil
+    }
+
+    private func load() {
+        if let decoded = try? JSONDecoder().decode([TrashedLocation].self, from: trashedData) {
+            trashedLocations = decoded
+        }
+    }
+
+    private func save() {
+        if let encoded = try? JSONEncoder().encode(trashedLocations) {
+            trashedData = encoded
+        }
+    }
+
+    private func removeExpiredAnimated() {
+        let expired = trashedLocations.filter { $0.isExpired }
+        if !expired.isEmpty {
+            for item in expired {
+                if let idx = trashedLocations.firstIndex(where: { $0.id == item.id }) {
+                    withAnimation(.easeOut) {
+                        trashedLocations.remove(at: idx)
+                    }
+                }
+            }
+            save()
+        }
+    }
+
+    func importantWeatherText(for model: LocationModel) -> String {
+        if model.condition.lowercased().contains("thunderstorm") { return "Severe Thunderstorm Risk: High" }
+        if model.condition.lowercased().contains("fog") { return "Visibility: Low" }
+        if model.temp > 100 { return "Heat Advisory: Stay Hydrated" }
+        if model.condition.lowercased().contains("rain") { return "Rain Chance: 80%" }
+        if model.temp < 32 { return "Freezing Risk: Take Care" }
+        return "Humidity: 78%"
+    }
+}
+
+private struct UndoSnackbar: View {
+    var undo: () -> Void
+    @State private var visible = true
+
+    var body: some View {
+        if visible {
+            HStack {
+                Text("Action completed")
+                Spacer()
+                Button("Undo", action: undo)
+            }
+            .padding()
+            .background(.ultraThinMaterial)
+            .cornerRadius(16)
+            .padding()
+            .onAppear {
+                let generator = UINotificationFeedbackGenerator()
+                generator.notificationOccurred(.success)
+            }
+            .onTapGesture { withAnimation { visible = false } }
+        }
+    }
+}
+
+#Preview {
+    TrashView()
+}


### PR DESCRIPTION
## Summary
- add a Trash tab to the nav bar
- add a TrashedLocation model
- provide TrashView to manage trashed locations with animated actions and undo snackbar
- soft delete locations from LocationsView
- show TrashView in ContentView

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438e564af4832b8650ad5b93afd7dd