### PR TITLE
Add forecast, radar, settings and chat views

### DIFF
--- a/SkyGraph/Components/Forecast/DailyLineGraph.swift
+++ b/SkyGraph/Components/Forecast/DailyLineGraph.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import Charts
+
+struct DailyForecastPoint: Identifiable {
+    let id = UUID()
+    let date: Date
+    let high: Double
+    let low: Double
+}
+
+struct DailyLineGraph: View {
+    var points: [DailyForecastPoint]
+
+    var body: some View {
+        Chart {
+            ForEach(points) { point in
+                LineMark(
+                    x: .value("Day", point.date),
+                    y: .value("High", point.high)
+                )
+                .foregroundStyle(Color("Graph Line 1"))
+                LineMark(
+                    x: .value("Day", point.date),
+                    y: .value("Low", point.low)
+                )
+                .foregroundStyle(Color("Graph Line 2"))
+            }
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+    }
+}

--- a/SkyGraph/Components/Forecast/ForecastDayCard.swift
+++ b/SkyGraph/Components/Forecast/ForecastDayCard.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct ForecastDayModel: Identifiable, Equatable {
+    let id = UUID()
+    let date: Date
+    let icon: String
+    let high: Double
+    let low: Double
+    let summary: String
+    let hourly: [Int]
+}
+
+struct ForecastDayCard: View {
+    var day: ForecastDayModel
+    @State private var showDetail = false
+
+    var body: some View {
+        Button(action: { showDetail = true }) {
+            VStack(spacing: 8) {
+                Image(systemName: day.icon)
+                    .font(.system(size: 30, weight: .bold))
+                    .foregroundStyle(
+                        LinearGradient(colors: [Color("Graph Line 1"), Color("Graph Line 2")], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    )
+                    .shadow(color: Color("Graph Line 1").opacity(0.2), radius: 4, y: 2)
+                Text(day.date, style: .date)
+                    .font(.headline)
+                    .foregroundColor(Color("Text Primary"))
+                HStack(spacing: 6) {
+                    Text("\(Int(day.high))°")
+                        .font(.subheadline.bold())
+                        .foregroundColor(Color("Graph Line 1"))
+                    Text("\(Int(day.low))°")
+                        .font(.subheadline.bold())
+                        .foregroundColor(Color("Graph Line 2"))
+                }
+                Text(day.summary)
+                    .font(.caption)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Color("Text Secondary"))
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity)
+            .background(
+                ZStack {
+                    GlassBackground(cornerRadius: 22)
+                    RoundedRectangle(cornerRadius: 22)
+                        .fill(Color("Card").opacity(0.6))
+                }
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 22)
+                    .stroke(Color("Graph Line 1").opacity(0.15), lineWidth: 1.2)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 22))
+        }
+        .buttonStyle(PlainButtonStyle())
+        .sheet(isPresented: $showDetail) {
+            ForecastDetailView(day: day)
+        }
+    }
+}
+
+struct ForecastDetailView: View {
+    var day: ForecastDayModel
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                Capsule()
+                    .fill(Color.gray.opacity(0.25))
+                    .frame(width: 46, height: 5)
+                    .padding(.top, 8)
+                Image(systemName: day.icon)
+                    .font(.system(size: 60))
+                    .foregroundStyle(
+                        LinearGradient(colors: [Color("Graph Line 1"), Color("Graph Line 2")], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    )
+                Text(day.summary)
+                    .font(.headline)
+                    .foregroundColor(Color("Text Primary"))
+                HourlyGraph(temps: day.hourly)
+                    .frame(height: 80)
+                    .padding(.horizontal)
+                // Additional stats - replace with real data
+                HStack {
+                    StatMiniCard(icon: "drop.fill", value: "10%", label: "Rain", color: Color("Graph Line 1"))
+                    StatMiniCard(icon: "wind", value: "8 mph", label: "Wind", color: Color("Graph Line 1"))
+                }
+            }
+            .padding()
+        }
+        .background(Color("Background").ignoresSafeArea())
+    }
+}
+
+

--- a/SkyGraph/Components/Forecast/HourlyGraph.swift
+++ b/SkyGraph/Components/Forecast/HourlyGraph.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Simple line graph used for hourly temps
+struct HourlyGraph: View {
+    let temps: [Int]
+
+    var body: some View {
+        GeometryReader { geo in
+            let points = temps.enumerated().map { idx, temp in
+                CGPoint(
+                    x: geo.size.width * CGFloat(idx) / CGFloat(max(temps.count - 1, 1)),
+                    y: geo.size.height - (geo.size.height * CGFloat(temp - (temps.min() ?? 0)) / CGFloat(max((temps.max() ?? 1) - (temps.min() ?? 0), 1)))
+                )
+            }
+            Path { path in
+                if points.count > 1 {
+                    path.move(to: points.first!)
+                    for pt in points.dropFirst() {
+                        path.addLine(to: pt)
+                    }
+                }
+            }
+            .stroke(
+                LinearGradient(colors: [Color("Graph Line 1"), Color("Graph Line 2")], startPoint: .topLeading, endPoint: .bottomTrailing),
+                style: StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round)
+            )
+            ForEach(Array(points.enumerated()), id: \.offset) { i, pt in
+                Circle()
+                    .fill(
+                        LinearGradient(colors: [Color("Graph Line 1"), Color("Graph Line 2")], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    )
+                    .frame(width: 9, height: 9)
+                    .position(pt)
+            }
+        }
+    }
+}

--- a/SkyGraph/ContentView.swift
+++ b/SkyGraph/ContentView.swift
@@ -16,39 +16,13 @@ struct ContentView: View {
                     case .home:
                         HomePageView(showLocations: $showLocations)  // Pass binding
                     case .forecast:
-                        Text("Forecast Page")
-                            .font(.largeTitle)
-                            .foregroundColor(.gray)
+                        ForecastView()
                     case .maps:
                         RadarView()
                     case .ai:
-                        Text("AI Page")
-                            .font(.largeTitle)
-                            .foregroundColor(.gray)
+                        AIChatView()
                     case .settings:
-                        NavigationView {
-                            List {
-                                ForEach(items) { item in
-                                    NavigationLink {
-                                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                                    } label: {
-                                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                                    }
-                                }
-                                .onDelete(perform: deleteItems)
-                            }
-                            .toolbar {
-                                ToolbarItem(placement: .navigationBarTrailing) {
-                                    EditButton()
-                                }
-                                ToolbarItem {
-                                    Button(action: addItem) {
-                                        Label("Add Item", systemImage: "plus")
-                                    }
-                                }
-                            }
-                            .navigationTitle("Settings / Items")
-                        }
+                        SettingsView()
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/SkyGraph/Views/AIChatView.swift
+++ b/SkyGraph/Views/AIChatView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct ChatMessage: Identifiable {
+    enum Sender { case user, bot }
+    let id = UUID()
+    let text: String
+    let sender: Sender
+}
+
+struct AIChatView: View {
+    @State private var messages: [ChatMessage] = [
+        ChatMessage(text: "Hi SkyBot!", sender: .user),
+        ChatMessage(text: "Hello! Ask me anything about the weather.", sender: .bot)
+    ]
+    @State private var input: String = ""
+
+    var body: some View {
+        VStack {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(spacing: 12) {
+                        ForEach(messages) { msg in
+                            messageBubble(msg)
+                                .id(msg.id)
+                        }
+                    }
+                    .padding()
+                }
+                .onChange(of: messages) { _ in
+                    withAnimation { proxy.scrollTo(messages.last?.id, anchor: .bottom) }
+                }
+            }
+
+            HStack {
+                TextField("Message", text: $input)
+                    .textFieldStyle(.roundedBorder)
+                Button(action: send) {
+                    Image(systemName: "paperplane.fill")
+                        .foregroundColor(Color("Graph Line 1"))
+                }
+            }
+            .padding()
+        }
+        .background(Color("Background").ignoresSafeArea())
+    }
+
+    @ViewBuilder
+    func messageBubble(_ msg: ChatMessage) -> some View {
+        HStack(alignment: .bottom) {
+            if msg.sender == .user { Spacer() }
+            if msg.sender == .bot {
+                Image("Logo")
+                    .resizable()
+                    .frame(width: 30, height: 30)
+                    .clipShape(Circle())
+            }
+            Text(msg.text)
+                .padding(10)
+                .background(
+                    ZStack {
+                        GlassBackground(cornerRadius: 18)
+                        RoundedRectangle(cornerRadius: 18)
+                            .fill(Color("Card").opacity(0.6))
+                    }
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18)
+                        .stroke(Color("Graph Line 1").opacity(0.15), lineWidth: 1)
+                )
+                .foregroundColor(Color("Text Primary"))
+            if msg.sender == .bot { Spacer() }
+        }
+    }
+
+    func send() {
+        guard !input.isEmpty else { return }
+        messages.append(ChatMessage(text: input, sender: .user))
+        // Placeholder bot response. Replace with API call
+        messages.append(ChatMessage(text: "I'll get back to you about that.", sender: .bot))
+        input = ""
+    }
+}
+
+#Preview {
+    AIChatView()
+}

--- a/SkyGraph/Views/ForecastView.swift
+++ b/SkyGraph/Views/ForecastView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ForecastView: View {
+    // Placeholder forecast data. Replace with API driven model
+    let forecast: [ForecastDayModel] = (0..<14).map { i in
+        ForecastDayModel(
+            date: Calendar.current.date(byAdding: .day, value: i, to: Date())!,
+            icon: ["cloud.fill","cloud.sun.fill","sun.max.fill","cloud.bolt.rain.fill"].randomElement()!,
+            high: Double.random(in: 60...90),
+            low: Double.random(in: 40...70),
+            summary: "Partly cloudy",
+            hourly: (0..<8).map { _ in Int.random(in: 50...90) }
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                Text("Forecast")
+                    .font(.largeTitle.bold())
+                    .foregroundColor(Color("Text Primary"))
+                    .padding(.top, 12)
+
+                DailyLineGraph(points: forecast.map { DailyForecastPoint(date: $0.date, high: $0.high, low: $0.low) })
+                    .frame(height: 200)
+                    .padding(.horizontal)
+
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                    ForEach(forecast) { day in
+                        ForecastDayCard(day: day)
+                    }
+                }
+                .padding(.bottom, 40)
+            }
+            .padding(.horizontal)
+        }
+        .background(Color("Background").ignoresSafeArea())
+    }
+}
+
+#Preview {
+    ForecastView()
+}

--- a/SkyGraph/Views/RadarView.swift
+++ b/SkyGraph/Views/RadarView.swift
@@ -1,8 +1,49 @@
 import SwiftUI
+import MapKit
 
 struct RadarView: View {
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 37.334_900, longitude: -122.009_020),
+        span: MKCoordinateSpan(latitudeDelta: 5, longitudeDelta: 5)
+    )
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack(alignment: .bottom) {
+            Map(coordinateRegion: $region)
+                .overlay(
+                    // Radar overlay placeholder. Replace with live tiles
+                    Image("radar_sample")
+                        .resizable()
+                        .scaledToFill()
+                        .opacity(0.6)
+                )
+                .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("San Francisco")
+                    .font(.headline)
+                    .foregroundColor(Color("Text Primary"))
+                Text("72° Partly Cloudy")
+                    .font(.title2.bold())
+                    .foregroundStyle(
+                        LinearGradient(colors: [Color("Graph Line 1"), Color("Graph Line 2")], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    )
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(
+                ZStack {
+                    GlassBackground(cornerRadius: 24)
+                    RoundedRectangle(cornerRadius: 24)
+                        .fill(Color("Card").opacity(0.6))
+                }
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 24)
+                    .stroke(Color("Graph Line 1").opacity(0.2), lineWidth: 1.4)
+            )
+            .padding()
+        }
     }
 }
 

--- a/SkyGraph/Views/SettingsView.swift
+++ b/SkyGraph/Views/SettingsView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var useMetric = false
+    @State private var theme: Int = 2 // 0 light,1 dark,2 auto
+    @State private var provider = 0
+    @State private var alertsEnabled = true
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                settingsGroup(title: "Units") {
+                    Toggle("Use Metric Units", isOn: $useMetric)
+                }
+
+                settingsGroup(title: "Theme") {
+                    Picker("Theme", selection: $theme) {
+                        Text("Light").tag(0)
+                        Text("Dark").tag(1)
+                        Text("Auto").tag(2)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                settingsGroup(title: "Weather Provider") {
+                    Picker("Provider", selection: $provider) {
+                        Text("Tomorrow.io").tag(0)
+                        Text("OpenWeather").tag(1)
+                        Text("WeatherKit").tag(2)
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                settingsGroup(title: "Notifications") {
+                    Toggle("Weather Alerts", isOn: $alertsEnabled)
+                }
+
+                settingsGroup(title: "About") {
+                    HStack {
+                        Text("Version 1.0")
+                        Spacer()
+                        Image("Logo")
+                            .resizable()
+                            .frame(width: 30, height: 30)
+                    }
+                }
+
+                Spacer(minLength: 40)
+            }
+            .padding()
+        }
+        .background(Color("Background").ignoresSafeArea())
+    }
+
+    @ViewBuilder
+    func settingsGroup<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .foregroundColor(Color("Text Primary"))
+            content()
+                .tint(Color("Graph Line 1"))
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            ZStack {
+                GlassBackground(cornerRadius: 22)
+                RoundedRectangle(cornerRadius: 22)
+                    .fill(Color("Card").opacity(0.6))
+            }
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 22)
+                .stroke(Color("Graph Line 1").opacity(0.15), lineWidth: 1.2)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 22))
+    }
+}
+
+#Preview {
+    SettingsView()
+}


### PR DESCRIPTION
## Summary
- implement ForecastView with 14‑day outlook and line graph
- add RadarView with map and glass overlay card
- create SettingsView with grouped glass cards
- build AIChatView for messaging with SkyBot
- integrate new views into ContentView navigation

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684463e20ab8832ba46201d77d043199